### PR TITLE
Fix path to `strip`

### DIFF
--- a/aarch64-linux-gnu
+++ b/aarch64-linux-gnu
@@ -2,7 +2,7 @@
 c = '/usr/bin/aarch64-linux-gnu-gcc'
 cpp = '/usr/bin/aarch64-linux-gnu-g++'
 ar = '/usr/bin/aarch64-linux-gnu-gcc-ar'
-strip = '/usr/bin/aarch64-linux-gnu-gcc-strip'
+strip = '/usr/bin/aarch64-linux-gnu-strip'
 pkgconfig = '/usr/bin/aarch64-linux-gnu-pkg-config'
 
 [host_machine]


### PR DESCRIPTION
Can be verified on the [archlinux package page](https://www.archlinux.org/packages/community/x86_64/aarch64-linux-gnu-binutils/).