### PR TITLE
add exe_wrapper = qemu-aarch64-static

### DIFF
--- a/aarch64-linux-gnu
+++ b/aarch64-linux-gnu
@@ -4,6 +4,7 @@ cpp = '/usr/bin/aarch64-linux-gnu-g++'
 ar = '/usr/bin/aarch64-linux-gnu-gcc-ar'
 strip = '/usr/bin/aarch64-linux-gnu-strip'
 pkgconfig = '/usr/bin/aarch64-linux-gnu-pkg-config'
+exe_wrapper = 'qemu-aarch64-static'
 
 [host_machine]
 system = 'linux'


### PR DESCRIPTION
[That's what igt uses](https://gitlab.freedesktop.org/drm/igt-gpu-tools/blob/master/meson-cross-arm64.txt), so it should work well enough (although they used the non-static version of it, but I put the static one here as it's probably more portable)

Note: you'll need to add a `depends+=(qemu-user-static-bin)` (or `qemu-arch-extra` if you go with the non-static one) to your PKGBUILD :)